### PR TITLE
case insensitive exact matching

### DIFF
--- a/rest_framework_word_filter/filter.py
+++ b/rest_framework_word_filter/filter.py
@@ -25,7 +25,7 @@ class FullWordSearchFilter(BaseFilterBackend):
         return ["{}__icontains".format(field_name),
                 "{}__istartswith".format(field_name),
                 "{}__iendswith".format(field_name),
-                "{}__exact".format(field_name),
+                "{}__iexact".format(field_name),
                 "{}__istartswith".format(field_name),
                 "{}__iendswith".format(field_name),
                 "{}__icontains".format(field_name),


### PR DESCRIPTION
A field with only a single word ('Hello') is returned only by search query of 'Hello' via exact match. With case-insensitive exact matching both 'hello' and 'Hello' queries returns the result.